### PR TITLE
tech: Remove Linux support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,7 @@ let package = Package(
 		.target(
 			name: "PactSwift",
 			dependencies: [
-				.product(name: "PactSwiftMockServer", package: "PactSwiftMockServer", condition: .when(platforms: [.iOS, .macOS, .tvOS])),
-				.product(name: "PactSwiftMockServerLinux", package: "PactSwiftMockServer", condition: .when(platforms: [.linux]))
+				.product(name: "PactSwiftMockServer", package: "PactSwiftMockServer", condition: .when(platforms: [.iOS, .macOS, .tvOS]))
 			],
 			path: "./Sources"
 		),

--- a/Sources/Toolbox/Logger.swift
+++ b/Sources/Toolbox/Logger.swift
@@ -16,9 +16,7 @@
 //
 
 import Foundation
-#if !os(Linux)
 import os.log
-#endif
 
 enum Logger {
 
@@ -38,17 +36,12 @@ enum Logger {
 		let stringData = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
 		if #available(iOS 10, OSX 10.14, *) {
-			#if !os(Linux)
 			os_log(
 				"PactSwift: %{private}s",
 				log: .default,
 				type: .default,
 				"\(message): \(stringData)"
 			)
-			#else
-			print(message: "PactSwift: \(message)\n\(stringData)")
-			#endif
-
 		} else {
 			print(message: "PactSwift: \(message)\n\(stringData)")
 		}

--- a/Tests/Services/PactContractTests.swift
+++ b/Tests/Services/PactContractTests.swift
@@ -19,10 +19,6 @@ import XCTest
 /*
 @testable import PactSwift
 
-#if os(Linux)
-import FoundationNetworking
-#endif
-
 private class MockServiceWrapper {
 	static let shared = MockServiceWrapper()
 
@@ -42,11 +38,7 @@ class PactContractTests: XCTestCase {
 
 	var mockService = MockServiceWrapper.shared.mockService
 
-	#if os(Linux)
-	let session = URLSession.shared
-	#else
 	let session = URLSession(configuration: .ephemeral)
-	#endif
 
 	static var errorCapture = MockServiceWrapper.shared.errorCapture
 	static let pactContractFileName = "\(MockServiceWrapper.shared.consumer)-\(MockServiceWrapper.shared.provider).json"


### PR DESCRIPTION
# 📝 Summary of Changes

Initial `PactSwift` implementation including `v1.x.x` focussed on supporting consumer and provider testing on macOS, iOS, tvOS and Linux platforms. That means there are a few preprocessor flags used such as `#if os(Linux)` to handle Linux specific frameworks and so on.

This fork focusses on supporting modern concurrency. Linux version of Swift is lags behind and so a decision has been made to drop support for Linux in this package. 

Perhaps a better approach would be a Linux specific `PactSwiftLinux` package where the specifics of Apple and Linux platforms would not conflict. Both can/should still depend on `PactSwiftMockServer` that provides the interface to `libpact_ffi` that allows alignment across different language implementations of Pact.

Changes proposed in this pull request:

- Remove `PactSwiftMockServerLinux` dependency
- Remove preprocessor flows for `Linux`

# ⚠️ Items of Note

When using this package on a SwiftUI project, the `PreviewProvider` was crashing because of Linux conflicts. Removing Linux support allows us to preview SwiftUI views in Xcode.

## 🔨 How To Test

In a iOS project, point `PactSwift` dependency to `tech/remove-linux-support` branch and run Pact tests. Pact test should run, pass (if they did before the change), and a Pact file is generated.